### PR TITLE
Can specify 'editable: true/false' in options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
     this.$el = $(el);
     this.options = $.extend({}, DayScheduleSelector.DEFAULTS, options);
     this.render();
-    this.attachEvents();
+    if(this.options.editable) { this.attachEvents(); }
     this.$selectingStart = null;
   }
 
@@ -14,6 +14,7 @@
     startTime   : '08:00',                // HH:mm format
     endTime     : '20:00',                // HH:mm format
     interval    : 30,                     // minutes
+    editable    : true,                   // false = view only mode
     template    : '<div class="day-schedule-selector">'         +
                     '<table class="schedule-table">'            +
                       '<thead class="schedule-header"></thead>' +
@@ -63,6 +64,9 @@
 
       $el.append('<tr><td class="time-label">' + hmmAmPm(d) + '</td>' + daysInARow + '</tr>');
     });
+
+    // If the selector is editable, the cursor should be a pointer.
+    if(this.options.editable) {  $("td.time-slot").css( 'cursor', 'pointer' ); }
   };
 
   /**


### PR DESCRIPTION
You can now specify in the options whether or not the selector should be read only. 
Example (maybe pretty redundant):

```
$("#weekly-schedule").dayScheduleSelector({
        interval: 60,
        startTime: '05:00',
        endTime: '24:00',
        editable: true
      });
```
