### PR TITLE
Serialization bugfix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
     this.$el = $(el);
     this.options = $.extend({}, DayScheduleSelector.DEFAULTS, options);
     this.render();
-    this.attachEvents();
+    if(this.options.editable) { this.attachEvents(); }
     this.$selectingStart = null;
   }
 
@@ -14,6 +14,7 @@
     startTime   : '08:00',                // HH:mm format
     endTime     : '20:00',                // HH:mm format
     interval    : 30,                     // minutes
+    editable    : true,                   // false = view only mode
     template    : '<div class="day-schedule-selector">'         +
                     '<table class="schedule-table">'            +
                       '<thead class="schedule-header"></thead>' +
@@ -63,6 +64,9 @@
 
       $el.append('<tr><td class="time-label">' + hmmAmPm(d) + '</td>' + daysInARow + '</tr>');
     });
+
+    // If the selector is editable, the cursor should be a pointer.
+    if(this.options.editable) {  $("td.time-slot").css( 'cursor', 'pointer' ); }
   };
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -161,9 +161,21 @@
       var start, end;
       start = end = false; selections[v] = [];
       plugin.$el.find(".time-slot[data-day='" + v + "']").each(function () {
+
+        // Is this the first slot selected?
         if (isSlotSelected($(this)) && !start) { start = $(this).data('time'); }
-        else if (!isSlotSelected($(this)) && !!start) {
+
+        // Is this slot not selected, and we have seen the start of a selection?
+        // Then this is an interval to be serialized.
+        if (!isSlotSelected($(this)) && !!start) {
           end = $(this).data('time');
+          selections[v].push([start, end]);
+          start = end = false;
+        }
+        // Finally, have we seen the start of a selection and have reached the final row of this column?
+        // Then we have a completed interval.
+        else if (!!start && $(this).is($("tbody.schedule-rows tr:last > td:nth-child("+(2+v)+")"))) {
+          end = plugin.options.endTime;
           selections[v].push([start, end]);
           start = end = false;
         }


### PR DESCRIPTION
When implementing I found that if you chose a timeslot in the last row of the table, the serialization fails for that column. This is because of this part of the serialization function:

```
        if (isSlotSelected($(this)) && !start) { start = $(this).data('time'); }
        else if (!isSlotSelected($(this)) && !!start) {
          end = $(this).data('time');
          selections[v].push([start, end]);
          start = end = false;
        }
```

The part that supplies the end of the selected block only checks if it has found a slot that is not selected. So if you select the final timeslot in a column it doesn't get triggered, and the selection is never pushed. I have added a check for this so that it now works as it should. 
